### PR TITLE
Add pagination support for completed items and projects

### DIFF
--- a/public/js/client.js
+++ b/public/js/client.js
@@ -28,4 +28,16 @@ window.onload = function() {
     ).innerText = persistentBackupUrl;
     window.location.replace(persistentBackupUrl);
   }
+
+  updateArchived(this);
 };
+
+function updateArchived(sender) { 
+  var archived = document.getElementById("archivedCbox");
+  if (document.getElementById("formatJSON").checked) {
+    archived.disabled = false;
+  } else {
+    archived.disabled = true;
+    archived.checked = false;
+  }
+}

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -19,12 +19,20 @@ block content
           div.radios
             div.radio
               label
-                input(type="radio", name="format", id="formatCSV", value="csv", checked="checked")
+                input(type="radio", name="format", id="formatCSV", value="csv", checked="checked" onchange="updateArchived(this)")
                 | CSV (only tasks)
             div.radio
               label
-                input(type="radio", name="format", id="formatJSON", value="json")
+                input(type="radio", name="format", id="formatJSON", value="json", onchange="updateArchived(this)")
                 | JSON (all data)
+        div.form-group#archived
+          label(for="archived")
+            strong Archived:
+          div.checkbox
+            label
+              input(type="checkbox", name="archived", id="archivedCbox")
+              | Export all
+              | (requires Todoist Premium and may take several minutes)
 
         div.text-center
           button#submit(type="submit")
@@ -41,6 +49,7 @@ block content
     h2 Changelog
 
     ul
+      li <strong>2021-02-15</strong>: Option to export all archived tasks and projects.
       li <strong>2020-02-02</strong>: The CSV format contains translated label, project and user names (instead of ID numbers).
       li <strong>2019-06-18</strong>: Updated to <a href="https://developer.todoist.com/sync/v8/#migration-guide" target="_blank" rel="noopener">API v8</a>. The output file schema has changed a little bit.
       li <strong>2016-09-01</strong>: Updated to API v7.


### PR DESCRIPTION
Hey @darekkay, this tool is wonderful! Thanks for open sourcing this.

Currently, the export only contains 30 each of completed items and projects ([the API default limit](https://developer.todoist.com/sync/v8/#get-all-completed-items)):

```
% cat ~/Downloads/todoist.json | jq .completed.items | jq length
30

% cat ~/Downloads/todoist.json | jq .completed.projects | jq length
30
```

This PR adds pagination support so all previously completed items / projects are exported:

![image](https://user-images.githubusercontent.com/6599399/102701206-8acdda80-4222-11eb-8a06-fc4eee9ad045.png)

```
% cat ~/Downloads/todoist.json | jq .completed.items | jq length
2702

% cat ~/Downloads/todoist.json | jq .completed.projects | jq length
220
```


