### PR TITLE
Use sync/v9/sync and send token in header, no support for completed

### DIFF
--- a/public/js/client.js
+++ b/public/js/client.js
@@ -1,27 +1,18 @@
 window.onload = function () {
-  var params = {};
-  location.search
-    .substr(1)
-    .split("&")
-    .forEach(function (item) {
-      var pair = item.split("="),
-        key = pair[0],
-        value = pair[1] && decodeURIComponent(pair[1]);
-      (params[key] = params[key] || []).push(value);
-    });
+  var params = new URLSearchParams(location.search)
 
-  if (params.code) {
+  if (params.has("code")) {
     window.location.replace(
-      "/todoist-export/export?code=" + params.code + "&format=" + params.state
+      "/todoist-export/export?code=" + params.get("code") + "&format=" + params.get("state")
     );
-  } else if (params.token) {
+  } else if (params.has("token")) {
     document.querySelector("#persistentBackup").style.display = "block";
     var persistentBackupUrl =
       window.location.href.split("?")[0] +
       "download?token=" +
-      params.token +
+      params.get("token") +
       "&format=" +
-      params.format;
+      params.get("format");
     document.querySelector("#persistentBackupUrl").href = persistentBackupUrl;
     document.querySelector("#persistentBackupUrl").innerText =
       persistentBackupUrl;

--- a/src/app.js
+++ b/src/app.js
@@ -91,8 +91,14 @@ app.get(`${subdirectory}/`, (req, res) => {
 const callApi = async (api, parameters) => {
   const response = await axios({
     method: "post",
-    url: `https://todoist.com/API/v9/${api}`,
+    headers: {
+      "Authorization": "Bearer " + parameters.token
+    },
+    url: `https://todoist.com/sync/v9/${api}`,
     data: parameters,
+  }).catch((error) => {
+    console.log(error);
+    throw new Error("Error calling Todoist API", error.response.status, error.response.data);
   });
   return response.data;
 };


### PR DESCRIPTION
Here is the update for new api, partially closes #20 

`callApi("completed/get_all", ...)` is not gonna work I think because I am not sure how it named now.